### PR TITLE
Update pulp.lua

### DIFF
--- a/pulp.lua
+++ b/pulp.lua
@@ -1695,7 +1695,6 @@ function pulp.__fn_restore(name)
 end
 
 function pulp.__fn_store(name)
-    assert(type(name) == "string")
     local value = pulp.getvariable(name)
     if type(value) ~= "table" then
         pulp.store[name] = value


### PR DESCRIPTION
The "store" function currently checks whether the variable to be stored is a string and crashes with an error if not.  As strings are not the only type of variable that is used with store, this is unnecessary.